### PR TITLE
Change pluginMap identifying parameter to unique id

### DIFF
--- a/lib/markdown-it-plugin-loader.coffee
+++ b/lib/markdown-it-plugin-loader.coffee
@@ -40,6 +40,7 @@ class MarkdownItPluginLoader
     projectPath = @getProjectPath()
 
     pluginMap = new Map()
+    id = 1
     plugins.forEach (entry) =>
       [name, args] = @destructurePluginEntry(entry)
       absolutePath = path.resolve(projectPath, 'node_modules', name)
@@ -47,7 +48,8 @@ class MarkdownItPluginLoader
       # test that the package exists and add it to the map if it does
       try
         require.resolve absolutePath
-        pluginMap.set(name, {absolutePath, args})
+        pluginMap.set(id, {absolutePath, args})
+        id++
       catch error
         atom.notifications.addError "MarkdownIt Plugin Loader couldn't find package #{name}", {dismissable: true}
 


### PR DESCRIPTION
Create `id` variable, set to `1`. Use `id` instead of `name` as identifier in `pluginMap.set`. Increment `id` so each is unique.

### Description of the Change

In markdown-it-plugin-loader.coffee, `pluginMap.set` (currently line 50) uses the `name` of a plugin as each entries identifier. This change uses a unique, incrementing `id` variable instead, keeping multiple instances of the same plugin from overwriting each other.

### Alternate Designs

Considered making more complex unique id values (ie `pluginname1`, `pluginname2`, etc) for each instance. As the code is currently written, this adds no real benefit and needlessly complicates code.

### Benefits

Allows multiple instances of the same plugin to load properly from markdown-it-plugin.config.js. Without this change, multiple instances (with the same plugin name) will overwrite each other and only the last will load successfully.

### Possible Drawbacks

The `name` parameter is not currently referenced after it is set to `pluginMap`, if this changes in the future, the code would need to be adjusted.

### Applicable Issues

None